### PR TITLE
Updates Madras Env to support multiple single agent trainings, parallely 

### DIFF
--- a/MADRaS/__init__.py
+++ b/MADRaS/__init__.py
@@ -4,6 +4,6 @@ from gym.envs.registration import register
 register(
     id='Madras-v0',
     entry_point='MADRaS.envs:MadrasEnv',
-    max_episode_steps=100,
+    max_episode_steps=10000,
     reward_threshold=25.0,
 )

--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -86,7 +86,7 @@ class MadrasEnv(TorcsEnv,gym.Env):
         if rank < self.no_of_visualisations and self.visualise:
             command = 'export TORCS_PORT={} && vglrun torcs -nolaptime'.format(self.port)
         else:
-            command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
+            command = 'export TORCS_PORT={} && vglrun torcs -t 10000000 -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
         if self.vision is True:
             command += ' -vision'
 

--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -30,7 +30,8 @@ class MadrasEnv(TorcsEnv,gym.Env):
     """Definition of the Gym Madras Env."""
     def __init__(self, vision=False, throttle=True,
                  gear_change=False, port=60934, pid_assist=False,
-                 CLIENT_MAX_STEPS=np.inf,visualise=True):
+                 CLIENT_MAX_STEPS=np.inf,visualise=True,no_of_visualisations=1):
+        # If `visualise` is set to False torcs simulator will run in headless mode
         """Init Method."""
         self.torcs_proc = None
         self.pid_assist = pid_assist
@@ -38,11 +39,12 @@ class MadrasEnv(TorcsEnv,gym.Env):
             self.action_dim = 2  # LanePos, Velocity
         else:
             self.action_dim = 3  # Accel, Steer, Brake
-        TorcsEnv.__init__(self, vision=False, throttle=True, gear_change=False,visualise=visualise)
+        TorcsEnv.__init__(self, vision=False, throttle=True, gear_change=False,visualise=visualise,no_of_visualisations=no_of_visualisations)
         self.state_dim = 29  # No. of sensors input
         self.env_name = 'Madras_Env'
         self.port = port
         self.visualise = visualise
+        self.no_of_visualisations = no_of_visualisations
         self.CLIENT_MAX_STEPS = CLIENT_MAX_STEPS
         self.client_type = 0  # Snakeoil client type
         self.initial_reset = True
@@ -81,7 +83,7 @@ class MadrasEnv(TorcsEnv,gym.Env):
         rank = MPI.COMM_WORLD.Get_rank()
 
         
-        if rank == 0 and self.visualise:
+        if rank < self.no_of_visualisations and self.visualise:
             command = 'export TORCS_PORT={} && vglrun torcs -nolaptime'.format(self.port)
         else:
             command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
@@ -115,19 +117,12 @@ class MadrasEnv(TorcsEnv,gym.Env):
         else:
             try:
                 self.ob, self.client = TorcsEnv.reset(self, client=self.client, relaunch=True)
-                # command = None
-                # if self.visualise:
-                #    command = 'export TORCS_PORT={} && vglrun torcs '.format(self.port)
-                # else:
-                #    command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml'.format(self.port)
-
-                # self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
-                # time.sleep(0.5)
             except Exception as e:
                 self.ob = None
                 while self.ob is None:
                     try:
-                        print("Stuck here")
+                        print("Hard Reset")
+                        # self.end(self.client)
                         self.client = snakeoil3.Client(p=self.port,
                                                        vision=self.vision)
                         # Open new UDP in vtorcs

--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -82,11 +82,12 @@ class MadrasEnv(TorcsEnv,gym.Env):
 
         
         if rank == 0 and self.visualise:
-            command = 'export TORCS_PORT={} && vglrun torcs '.format(self.port)
+            command = 'export TORCS_PORT={} && vglrun torcs -nolaptime'.format(self.port)
         else:
-            command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml'.format(self.port)
+            command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
         if self.vision is True:
             command += ' -vision'
+            
         self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
         time.sleep(0.5)
         #if self.visualise:

--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -115,7 +115,15 @@ class MadrasEnv(TorcsEnv,gym.Env):
 
         else:
             try:
-		self.ob, self.client = TorcsEnv.reset(self, client=self.client, relaunch=True)
+		        self.ob, self.client = TorcsEnv.reset(self, client=self.client, relaunch=True)
+                command = None
+                if self.visualise:
+                    command = 'export TORCS_PORT={} && vglrun torcs '.format(self.port)
+                else:
+                    command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml'.format(self.port)
+
+                self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
+                time.sleep(0.5)
             except Exception as e:
                 self.ob = None
                 while self.ob is None:

--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -30,14 +30,15 @@ class MadrasEnv(TorcsEnv,gym.Env):
     """Definition of the Gym Madras Env."""
     def __init__(self, vision=False, throttle=True,
                  gear_change=False, port=60934, pid_assist=False,
-                 CLIENT_MAX_STEPS=np.inf,visualise=True):
+                 CLIENT_MAX_STEPS=np.inf,visualise=False):
         """Init Method."""
+        self.torcs_proc = None
         self.pid_assist = pid_assist
         if self.pid_assist:
             self.action_dim = 2  # LanePos, Velocity
         else:
             self.action_dim = 3  # Accel, Steer, Brake
-        TorcsEnv.__init__(self, vision=False, throttle=True, gear_change=False)
+        TorcsEnv.__init__(self, vision=False, throttle=True, gear_change=False,visualise=visualise)
         self.state_dim = 29  # No. of sensors input
         self.env_name = 'Madras_Env'
         self.port = port
@@ -59,7 +60,6 @@ class MadrasEnv(TorcsEnv,gym.Env):
         self.prev_dist = 0
         self.ob = None
         self.track_len = 7014.6
-        self.torcs_proc = None
         self.start_torcs_process()
         
     def get_free_udp_port(self):
@@ -87,12 +87,11 @@ class MadrasEnv(TorcsEnv,gym.Env):
             command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
         if self.vision is True:
             command += ' -vision'
-            
+
         self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
-        time.sleep(0.5)
+        time.sleep(1)
         #if self.visualise:
         #    os.system('sh autostart.sh {}'.format(window_title))
-        time.sleep(0.5)
 
    
     def reset(self, prev_step_info=None):
@@ -115,19 +114,20 @@ class MadrasEnv(TorcsEnv,gym.Env):
 
         else:
             try:
-                self.ob, self.client = TorcsEnv.reset(self, client=self.client, relaunch=False)
-                #command = None
-                #if self.visualise:
+                self.ob, self.client = TorcsEnv.reset(self, client=self.client, relaunch=True)
+                # command = None
+                # if self.visualise:
                 #    command = 'export TORCS_PORT={} && vglrun torcs '.format(self.port)
-                #else:
+                # else:
                 #    command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml'.format(self.port)
 
-                #self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
-                #time.sleep(0.5)
+                # self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
+                # time.sleep(0.5)
             except Exception as e:
                 self.ob = None
                 while self.ob is None:
                     try:
+                        print("Stuck here")
                         self.client = snakeoil3.Client(p=self.port,
                                                        vision=self.vision)
                         # Open new UDP in vtorcs
@@ -200,6 +200,7 @@ class MadrasEnv(TorcsEnv,gym.Env):
             if self.distance_traversed >= self.track_len:
                 done = True
             if done:
+                # self.reset()
                 break
 
         s_t1 = np.hstack((self.ob.angle, self.ob.track, self.ob.trackPos,

--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -30,7 +30,7 @@ class MadrasEnv(TorcsEnv,gym.Env):
     """Definition of the Gym Madras Env."""
     def __init__(self, vision=False, throttle=True,
                  gear_change=False, port=60934, pid_assist=False,
-                 CLIENT_MAX_STEPS=np.inf,visualise=False):
+                 CLIENT_MAX_STEPS=np.inf,visualise=True):
         """Init Method."""
         self.torcs_proc = None
         self.pid_assist = pid_assist

--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -81,8 +81,7 @@ class MadrasEnv(TorcsEnv,gym.Env):
         rank = MPI.COMM_WORLD.Get_rank()
 
         
-
-        if self.visualise:
+        if rank == 0 and self.visualise:
             command = 'export TORCS_PORT={} && vglrun torcs '.format(self.port)
         else:
             command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml'.format(self.port)
@@ -101,7 +100,7 @@ class MadrasEnv(TorcsEnv,gym.Env):
             while self.ob is None:
                 try:
                     self.client = snakeoil3.Client(p=self.port,
-                                                   vision=self.vision)
+                                                   vision=self.vision,visualise=self.visualise)
                     # Open new UDP in vtorcs
                     self.client.MAX_STEPS = self.CLIENT_MAX_STEPS
                     self.client.get_servers_input(step=0)
@@ -115,15 +114,15 @@ class MadrasEnv(TorcsEnv,gym.Env):
 
         else:
             try:
-		        self.ob, self.client = TorcsEnv.reset(self, client=self.client, relaunch=True)
-                command = None
-                if self.visualise:
-                    command = 'export TORCS_PORT={} && vglrun torcs '.format(self.port)
-                else:
-                    command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml'.format(self.port)
+                self.ob, self.client = TorcsEnv.reset(self, client=self.client, relaunch=False)
+                #command = None
+                #if self.visualise:
+                #    command = 'export TORCS_PORT={} && vglrun torcs '.format(self.port)
+                #else:
+                #    command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml'.format(self.port)
 
-                self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
-                time.sleep(0.5)
+                #self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
+                #time.sleep(0.5)
             except Exception as e:
                 self.ob = None
                 while self.ob is None:

--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -13,20 +13,24 @@ The following enhancements were made for Multi-agent synchronization using excep
 """
 
 import math
-import gym
 from copy import deepcopy
 import numpy as np
 import MADRaS.utils.snakeoil3_gym as snakeoil3
 from MADRaS.utils.gym_torcs import TorcsEnv
 from MADRaS.controllers.pid import PID
+import gym
+import os
+import subprocess
+import signal
+import time
+from mpi4py import MPI
+import socket
 
-
-
-class MadrasEnv(TorcsEnv, gym.Env):
+class MadrasEnv(TorcsEnv,gym.Env):
     """Definition of the Gym Madras Env."""
     def __init__(self, vision=False, throttle=True,
-                 gear_change=False, port=3001, pid_assist=True,
-                 CLIENT_MAX_STEPS=np.inf):
+                 gear_change=False, port=60934, pid_assist=False,
+                 CLIENT_MAX_STEPS=np.inf,visualise=True):
         """Init Method."""
         self.pid_assist = pid_assist
         if self.pid_assist:
@@ -37,6 +41,7 @@ class MadrasEnv(TorcsEnv, gym.Env):
         self.state_dim = 29  # No. of sensors input
         self.env_name = 'Madras_Env'
         self.port = port
+        self.visualise = visualise
         self.CLIENT_MAX_STEPS = CLIENT_MAX_STEPS
         self.client_type = 0  # Snakeoil client type
         self.initial_reset = True
@@ -54,7 +59,42 @@ class MadrasEnv(TorcsEnv, gym.Env):
         self.prev_dist = 0
         self.ob = None
         self.track_len = 7014.6
+        self.torcs_proc = None
+        self.start_torcs_process()
+        
+    def get_free_udp_port(self):
+        udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        udp.bind(('', 0))
+        addr, port = udp.getsockname()
+        udp.close()
+        return port
 
+    def start_torcs_process(self):
+        if self.torcs_proc is not None:
+            os.killpg(os.getpgid(self.torcs_proc.pid), signal.SIGKILL)
+            time.sleep(0.5)
+            self.torcs_proc = None
+
+        self.port = self.get_free_udp_port()
+        window_title = str(self.port)
+        command = None
+        rank = MPI.COMM_WORLD.Get_rank()
+
+        
+
+        if self.visualise:
+            command = 'export TORCS_PORT={} && vglrun torcs '.format(self.port)
+        else:
+            command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml'.format(self.port)
+        if self.vision is True:
+            command += ' -vision'
+        self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
+        time.sleep(0.5)
+        #if self.visualise:
+        #    os.system('sh autostart.sh {}'.format(window_title))
+        time.sleep(0.5)
+
+   
     def reset(self, prev_step_info=None):
         """Reset Method. To be called at the end of each episode"""
         if self.initial_reset:
@@ -75,9 +115,7 @@ class MadrasEnv(TorcsEnv, gym.Env):
 
         else:
             try:
-                self.ob, self.client =\
-                    TorcsEnv.reset(self, client=self.client, relaunch=True)
-
+		self.ob, self.client = TorcsEnv.reset(self, client=self.client, relaunch=True)
             except Exception as e:
                 self.ob = None
                 while self.ob is None:

--- a/MADRaS/utils/gym_torcs.py
+++ b/MADRaS/utils/gym_torcs.py
@@ -220,7 +220,7 @@ class TorcsEnv:
         if rank < self.no_of_visualisations and self.visualise:
             command = 'export TORCS_PORT={} && vglrun torcs -nolaptime'.format(client.port)
         else:
-            command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(client.port)
+            command = 'export TORCS_PORT={} && vglrun torcs -t 10000000 -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(client.port)
         if self.vision is True:
             command += ' -vision'
 

--- a/MADRaS/utils/gym_torcs.py
+++ b/MADRaS/utils/gym_torcs.py
@@ -223,7 +223,7 @@ class TorcsEnv:
 
         self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
         #self.torcs_proc = subprocess.Popen([command], shell=True)
-        time.sleep(10)
+        time.sleep(1)
 
     def agent_to_torcs(self, u):
         torcs_action = {'steer': u[0]}

--- a/MADRaS/utils/gym_torcs.py
+++ b/MADRaS/utils/gym_torcs.py
@@ -156,7 +156,8 @@ class TorcsEnv:
 
         if client.R.d['meta'] is True: # Send a reset signal
             self.initial_run = False
-            client.respond_to_server()
+            #client.respond_to_server()
+            self.reset(client)
 
         self.time_step += 1
 
@@ -178,7 +179,7 @@ class TorcsEnv:
                 print("### TORCS is RELAUNCHED ###")
 
         # Modify here if you use multiple tracks in the environment
-        client = snakeoil3.Client(p=port, vision=self.vision)  # Open new UDP in vtorcs
+        client = snakeoil3.Client(p=port, vision=self.vision,visualise=self.visualise)  # Open new UDP in vtorcs
         client.MAX_STEPS = np.inf
 
         # client = self.client

--- a/MADRaS/utils/snakeoil3_gym.py
+++ b/MADRaS/utils/snakeoil3_gym.py
@@ -229,7 +229,7 @@ class Client(object):
                     if rank < self.no_of_visualisations and self.visualise:
                         command = 'export TORCS_PORT={} && vglrun torcs -nolaptime'.format(self.port)
                     else:
-                        command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
+                        command = 'export TORCS_PORT={} && vglrun torcs -t 10000000  -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
                     if self.vision is True:
                         command += ' -vision'
                     self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)

--- a/MADRaS/utils/snakeoil3_gym.py
+++ b/MADRaS/utils/snakeoil3_gym.py
@@ -139,12 +139,13 @@ class Client(object):
     """The class implementation of the server client model."""
 
     def __init__(self, H=None, p=None, i=None,
-                 e=None, t=None, s=None, d=None, vision=False,visualise=True):
+                 e=None, t=None, s=None, d=None, vision=False,visualise=True,no_of_visualisations=1):
         """Init method for class Client."""
         self.serverPID = None
         self.vision = vision
         self.host = 'localhost'
         self.visualise=visualise
+        self.no_of_visualisations = no_of_visualisations
         self.port = 3001
         self.sid = 'SCR'
         self.maxEpisodes = 1  # "Maximum number of episodes to perform"
@@ -225,7 +226,7 @@ class Client(object):
                     command = None
                     rank = MPI.COMM_WORLD.Get_rank()
 
-                    if rank == 0 and self.visualise:
+                    if rank < self.no_of_visualisations and self.visualise:
                         command = 'export TORCS_PORT={} && vglrun torcs -nolaptime'.format(self.port)
                     else:
                         command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)

--- a/MADRaS/utils/snakeoil3_gym.py
+++ b/MADRaS/utils/snakeoil3_gym.py
@@ -141,6 +141,7 @@ class Client(object):
     def __init__(self, H=None, p=None, i=None,
                  e=None, t=None, s=None, d=None, vision=False,visualise=True):
         """Init method for class Client."""
+        self.serverPID = None
         self.vision = vision
         self.host = 'localhost'
         self.visualise=visualise
@@ -169,9 +170,11 @@ class Client(object):
         self.S = ServerState()
         self.R = DriverAction()
         self.setup_connection()
+        
 
     def setup_connection(self):
         """Set Up UDP Socket."""
+        print("Trying to set connection")
         try:
             self.so = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         except socket.error as emsg:
@@ -180,7 +183,7 @@ class Client(object):
         # == Initialize Connection To Server ==
         self.so.settimeout(1)
 
-        n_fail = 50
+        n_fail = 15
         while True:
             """This string establishes track sensor angles!
             You can customize them.
@@ -193,6 +196,7 @@ class Client(object):
             initmsg = '%s(init %s)' % (self.sid, a)
 
             try:
+                print('Trying to establish connection')
                 self.so.sendto(initmsg.encode(), (self.host, self.port))
             except socket.error as emsg:
                 sys.exit(-1)
@@ -204,17 +208,20 @@ class Client(object):
                 print("Waiting for server on %d............" % self.port)
                 print("Count Down : " + str(n_fail))
                 if n_fail < 0:
-                    print("relaunch torcs")
-                    os.system('pkill torcs')
+                    print("relaunch torcs in snakeoil")
+                    if self.serverPID is not None:
+                        command = 'kill {}'.format(self.serverPID)
+                        os.system(command)
+                        self.serverPID = None
                     time.sleep(1.0)
 
-                    """if self.vision is False:
-                    os.system(u'torcs -nofuel -nodamage -nolaptime &')
-                    else:
-                    os.system(u'torcs -nofuel -nodamage -nolaptime -vision &')
-                    time.sleep(1.0)
-                    """
-                    #os.system('sh scripts/autostart.sh')
+                    # if self.vision is False:
+                    #     os.system(u'torcs -nofuel -nodamage -nolaptime &')
+                    # else:
+                    #     os.system(u'torcs -nofuel -nodamage -nolaptime -vision &')
+                    # time.sleep(1.0)
+                    
+                    # os.system('sh scripts/autostart.sh')
                     command = None
                     rank = MPI.COMM_WORLD.Get_rank()
 

--- a/MADRaS/utils/snakeoil3_gym.py
+++ b/MADRaS/utils/snakeoil3_gym.py
@@ -219,9 +219,9 @@ class Client(object):
                     rank = MPI.COMM_WORLD.Get_rank()
 
                     if rank == 0 and self.visualise:
-                        command = 'export TORCS_PORT={} && vglrun torcs '.format(self.port)
+                        command = 'export TORCS_PORT={} && vglrun torcs -nolaptime'.format(self.port)
                     else:
-                        command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml'.format(self.port)
+                        command = 'export TORCS_PORT={} && vglrun torcs -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
                     if self.vision is True:
                         command += ' -vision'
                     self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
@@ -232,7 +232,10 @@ class Client(object):
 
             identify = '***identified***'
             if identify in sockdata:
+                data = sockdata.split(':')
+                self.serverPID = int(data[1].rstrip('\x00'))
                 print("Client connected on %d.............." % self.port)
+                print("Server PID is %d.............." % self.serverPID)
                 break
 
     def parse_the_command_line(self):


### PR DESCRIPTION
What this PR adds to the Env
1. Updates Madras Env with the auto launch of torcs on a random vacant port.
2. Supports parallel agents.

Why this PR is required is 
1. For parallel training of single agents.

Testing:
1. Clone the baselines and MADRaS repos.
2. Install editable copies of both using `pip install -e .`.
3. run `python -m baselines.run --alg='ddpg' --env='Madras-v0'` from baselines folder for single agent training.
4. run `mpirun -np 4 python -m baselines.run --alg='ddpg' --env='Madras-v0'` from baselines folder for parallel single agent training.