### PR TITLE
[WIP] Traffic Integration

### DIFF
--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -85,12 +85,15 @@ class MadrasEnv(TorcsEnv,gym.Env):
         
         if rank < self.no_of_visualisations and self.visualise:
             command = 'export TORCS_PORT={} && vglrun torcs -nolaptime'.format(self.port)
+            command1 = 'python -m MADRaS.traffic.const_vel {} 50 0 0'.format(self.port+1)
         else:
             command = 'export TORCS_PORT={} && vglrun torcs -t 10000000 -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
         if self.vision is True:
             command += ' -vision'
-
+        print("TRIED TO START TRAFFIC")
         self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
+        self.traffic_proc = subprocess.Popen([command1], shell=True, preexec_fn=os.setsid)
+        
         time.sleep(1)
         #if self.visualise:
         #    os.system('sh autostart.sh {}'.format(window_title))

--- a/MADRaS/traffic/const_vel.py
+++ b/MADRaS/traffic/const_vel.py
@@ -1,18 +1,21 @@
 """Constant velocity Traffic Agent."""
 import sys
-import yaml
 import numpy as np
-from controllers.pid import PID
-from utils.gym_torcs import TorcsEnv
-import utils.snakeoil3_gym as snakeoil3
-from utils.madras_datatypes import Madras
+from MADRaS.controllers.pid import PID
+from MADRaS.utils.gym_torcs import TorcsEnv
+import MADRaS.utils.snakeoil3_gym as snakeoil3
+from MADRaS.utils.madras_datatypes import Madras
 
 madras = Madras()
-with open("./traffic/configurations.yml", "r") as ymlfile:
-    cfg = yaml.load(ymlfile)
 
 
-def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
+
+def playTraffic(port=3101,
+                target_vel=50.0,
+                angle=0.0,
+                sleep=0,
+                max_steps=100000,
+                episode_count=50):
     """Traffic Play function."""
     env = TorcsEnv(vision=False, throttle=True, gear_change=False)
     ob = None
@@ -25,8 +28,6 @@ def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
             ob = env.make_observation(obs)
         except:
             pass
-    episode_count = cfg['traffic']['max_eps']
-    max_steps = cfg['traffic']['max_steps_eps']
     early_stop = 0
     velocity = target_vel / 300.0
     accel_pid = PID(np.array([10.5, 0.05, 2.8]))
@@ -65,7 +66,6 @@ def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
             opp = ob.opponents
             front = np.array([opp[15], opp[16], opp[17], opp[18], opp[19]])
             closest_front = np.min(front)
-            print(ob.speedX * 300)
             vel_error = velocity - ob.speedX
             angle_error = -(ob.trackPos - angle) / 10 + ob.angle
             steer_pid.update_error(angle_error)
@@ -82,6 +82,7 @@ def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
                 brake = 0
         try:
             if 'termination_cause' in info.keys() and info['termination_cause'] == 'hardReset':
+                print(info)
                 print('Hard reset by some agent')
                 ob, client = env.reset(client=client, relaunch=True)
 

--- a/MADRaS/utils/gym_torcs.py
+++ b/MADRaS/utils/gym_torcs.py
@@ -219,12 +219,14 @@ class TorcsEnv:
         rank = MPI.COMM_WORLD.Get_rank()        
         if rank < self.no_of_visualisations and self.visualise:
             command = 'export TORCS_PORT={} && vglrun torcs -nolaptime'.format(client.port)
+            command1 = 'python -m MADRaS.traffic.const_vel {} 50 0 0'.format(self.port+1)
         else:
             command = 'export TORCS_PORT={} && vglrun torcs -t 10000000 -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(client.port)
         if self.vision is True:
             command += ' -vision'
 
         self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
+        self.traffic_proc = subprocess.Popen([command1], shell=True, preexec_fn=os.setsid)
         #self.torcs_proc = subprocess.Popen([command], shell=True)
         time.sleep(1)
 

--- a/MADRaS/utils/snakeoil3_gym.py
+++ b/MADRaS/utils/snakeoil3_gym.py
@@ -228,11 +228,13 @@ class Client(object):
 
                     if rank < self.no_of_visualisations and self.visualise:
                         command = 'export TORCS_PORT={} && vglrun torcs -nolaptime'.format(self.port)
+                        command1 = 'python -m MADRaS.traffic.const_vel {} 50 0 0'.format(self.port+1)
                     else:
                         command = 'export TORCS_PORT={} && vglrun torcs -t 10000000  -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
                     if self.vision is True:
                         command += ' -vision'
                     self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)
+                    self.traffic_proc = subprocess.Popen([command1], shell=True, preexec_fn=os.setsid)
                     time.sleep(0.5)
                     
                     n_fail = 50


### PR DESCRIPTION
Why?
As of now, the new API does not support training with traffic. Hence there is a need for the addition of that feature.

What?
The following pr provides a naive implementation of the feature. By creating subprocesses for each traffic.

Testing:

- Change the configuration of the torcs simulator by opening it and adding `scr-server2` along with scr-1.
- Testing code
```python
import gym
import MADRaS
env_name = 'Madras-v0'
env = gym.make(env_name)
env.reset()
for i in range(1000):
    print("STER: {}".format(i))
    env.step(env.action_space.sample()) # take a random action
print('#################OVER####################')
env.reset()
for i in range(1000):
    print("STER: {}".format(i))
    ob, r, done, info  = env.step(env.action_space.sample()) # take a random 
env.close()
```
NOTE:
- Upon the first reset the sim will show
```shell
Waiting for server on 55434............
Count Down : 1
Trying to establish connection
```
But I have checked the observations keep coming and the traffic agent also works properly. 