### PR TITLE
Support for multi agent mode of training and custom traffic agents

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"

--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -84,9 +84,9 @@ class MadrasEnv(TorcsEnv,gym.Env):
 
         
         if rank < self.no_of_visualisations and self.visualise:
-            command = 'export TORCS_PORT={} && vglrun torcs -nolaptime'.format(self.port)
+            command = 'export TORCS_PORT={} && vglrun torcs -t 10000000 -nolaptime'.format(self.port)
         else:
-            command = 'export TORCS_PORT={} && vglrun torcs -t 10000000 -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
+            command = 'export TORCS_PORT={} && torcs -t 10000000 -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
         if self.vision is True:
             command += ' -vision'
 

--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -39,13 +39,15 @@ class MadrasEnv(TorcsEnv,gym.Env):
     """Definition of the Gym Madras Env."""
     def __init__(self, vision=False, throttle=True,
                  gear_change=False, port=60934, pid_assist=False,
-                 CLIENT_MAX_STEPS=np.inf,visualise=False,no_of_visualisations=1, multi_agent_mode=False , traffic_type=[3,3,3]):
+                 CLIENT_MAX_STEPS=np.inf,visualise=True,no_of_visualisations=1, multi_agent_mode=False ,random_traffic=True, traffic_type=[3,3,3]):
         # traffic_type is a list of traffic agents.
         # If `visualise` is set to False torcs simulator will run in headless mode
         """Init Method."""
         self.torcs_proc = None
         self.pid_assist = pid_assist
         self.traffic_type = traffic_type
+        if random_traffic:
+            self.traffic_type = np.random.randint(0,4,3)
         if self.pid_assist:
             self.action_dim = 2  # LanePos, Velocity
         else:
@@ -121,7 +123,7 @@ class MadrasEnv(TorcsEnv,gym.Env):
             self.traffic_processes = []
             
             self.ports = [self.port+p for p in range(1+len(self.traffic_type))]
-            index = random.randint(1,len(self.ports)-1)
+            index = random.randint(2,len(self.ports)-1)
 
             self.mainport = self.ports.pop(index)
 

--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -31,7 +31,7 @@ class MadrasEnv(TorcsEnv,gym.Env):
     """Definition of the Gym Madras Env."""
     def __init__(self, vision=False, throttle=True,
                  gear_change=False, port=60934, pid_assist=False,
-                 CLIENT_MAX_STEPS=np.inf,visualise=True,no_of_visualisations=1):
+                 CLIENT_MAX_STEPS=np.inf,visualise=True,no_of_visualisations=1, multi_agent_mode=False):
         # If `visualise` is set to False torcs simulator will run in headless mode
         """Init Method."""
         self.torcs_proc = None
@@ -64,7 +64,8 @@ class MadrasEnv(TorcsEnv,gym.Env):
         self.ob = None
         self.track_len = 7014.6
         self.seed()
-        self.start_torcs_process()
+        if multi_agent_mode == False:
+            self.start_torcs_process()
 
     def seed(self, seed=None):
         self.np_random, seed = seeding.np_random(seed)

--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -39,7 +39,7 @@ class MadrasEnv(TorcsEnv,gym.Env):
     """Definition of the Gym Madras Env."""
     def __init__(self, vision=False, throttle=True,
                  gear_change=False, port=60934, pid_assist=False,
-                 CLIENT_MAX_STEPS=np.inf,visualise=True,no_of_visualisations=1, multi_agent_mode=False ,random_traffic=True, traffic_type=[3,3,3]):
+                 CLIENT_MAX_STEPS=np.inf,visualise=True,no_of_visualisations=1, multi_agent_mode=False ,random_traffic=True, traffic_type=[]):
         # traffic_type is a list of traffic agents.
         # If `visualise` is set to False torcs simulator will run in headless mode
         """Init Method."""
@@ -172,8 +172,10 @@ class MadrasEnv(TorcsEnv,gym.Env):
 
                 self.traffic_processes = []                                
                 self.ports = [self.port+p for p in range(1+len(self.traffic_type))]
-                index = random.randint(1,len(self.ports)-1)
-                self.oldpos = index+1
+                index = 0
+                if len(self.traffic_type) != 0:                
+                    index = random.randint(1,len(self.ports)-1)
+                self.oldpos = index+1                
                 self.mainport = self.ports.pop(index)
 
 
@@ -286,7 +288,7 @@ class MadrasEnv(TorcsEnv,gym.Env):
                 print("Overtakeen by traffic")
                 r_t -= 10000
 
-            if self.client.S.d['racePos'] == 1:
+            if self.client.S.d['racePos'] == 1 and (len(self.traffic_type) != 0):
                 print("Reached Position 1 - Resetting")
                 done = True
                 r_t += 50000

--- a/MADRaS/traffic/configurations.yml
+++ b/MADRaS/traffic/configurations.yml
@@ -1,5 +1,5 @@
 traffic:
-  max_steps_eps: 10000
+  max_steps_eps: 100000
   max_eps: 5000
   amplitude: 50.0
   time_period: 300.0

--- a/MADRaS/traffic/const_vel.py
+++ b/MADRaS/traffic/const_vel.py
@@ -2,17 +2,17 @@
 import sys
 import yaml
 import numpy as np
-from controllers.pid import PID
-from utils.gym_torcs import TorcsEnv
-import utils.snakeoil3_gym as snakeoil3
-from utils.madras_datatypes import Madras
+from MADRaS.controllers.pid import PID
+from MADRaS.utils.gym_torcs import TorcsEnv
+import MADRaS.utils.snakeoil3_gym as snakeoil3
+from MADRaS.utils.madras_datatypes import Madras
 
 madras = Madras()
 with open("./traffic/configurations.yml", "r") as ymlfile:
     cfg = yaml.load(ymlfile)
 
 
-def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
+def playTraffic(port=3101, target_vel=500.0, angle=0.0, sleep=0):
     """Traffic Play function."""
     env = TorcsEnv(vision=False, throttle=True, gear_change=False)
     ob = None
@@ -34,7 +34,7 @@ def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
     steer = 0.0
     accel = 0.0
     brake = 0
-    print(velocity)
+    # print(velocity)
     for i in range(episode_count):
         info = {'termination_cause': 0}
         steer = 0.0
@@ -60,12 +60,12 @@ def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
                         pass
                     continue
             if (step <= sleep):
-                print("WAIT" + str(port))
+                # print("WAIT" + str(port))
                 continue
             opp = ob.opponents
             front = np.array([opp[15], opp[16], opp[17], opp[18], opp[19]])
             closest_front = np.min(front)
-            print(ob.speedX * 300)
+            # print(ob.speedX * 300)
             vel_error = velocity - ob.speedX
             angle_error = -(ob.trackPos - angle) / 10 + ob.angle
             steer_pid.update_error(angle_error)

--- a/MADRaS/traffic/const_vel.py
+++ b/MADRaS/traffic/const_vel.py
@@ -8,11 +8,11 @@ import MADRaS.utils.snakeoil3_gym as snakeoil3
 from MADRaS.utils.madras_datatypes import Madras
 
 madras = Madras()
-with open("./traffic/configurations.yml", "r") as ymlfile:
+with open("./MADRaS/MADRaS/traffic/configurations.yml", "r") as ymlfile:
     cfg = yaml.load(ymlfile)
 
 
-def playTraffic(port=3101, target_vel=500.0, angle=0.0, sleep=0):
+def playTraffic(port=3101, target_vel=80.0, angle=0.0, sleep=0):
     """Traffic Play function."""
     env = TorcsEnv(vision=False, throttle=True, gear_change=False)
     ob = None
@@ -45,7 +45,8 @@ def playTraffic(port=3101, target_vel=500.0, angle=0.0, sleep=0):
             try:
                 ob, r_t, done, info = env.step(step, client, a_t, early_stop)
                 if done:
-                    break
+                    # break
+                    pass
             except Exception as e:
                 print("Exception caught at port " + str(i) + str(e))
                 ob = None

--- a/MADRaS/traffic/const_vel_s.py
+++ b/MADRaS/traffic/const_vel_s.py
@@ -2,8 +2,8 @@
 
 import sys
 import numpy as np
-import utils.snakeoil3_gym as snakeoil3
-from utils.madras_datatypes import Madras
+import MADRaS.utils.snakeoil3_gym as snakeoil3
+from MADRaS.utils.madras_datatypes import Madras
 
 madras = Madras()
 PORT = madras.intX(sys.argv[1])

--- a/MADRaS/traffic/lane_switch.py
+++ b/MADRaS/traffic/lane_switch.py
@@ -10,13 +10,13 @@ import MADRaS.utils.snakeoil3_gym as snakeoil3
 from MADRaS.utils.madras_datatypes import Madras
 
 madras = Madras()
-with open("./traffic/configurations.yml", "r") as ymlfile:
+with open("./MADRaS/MADRaS/traffic/configurations.yml", "r") as ymlfile:
     cfg = yaml.load(ymlfile)
 
 random.seed(time.time())
 
 
-def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
+def playTraffic(port=3101, target_vel=80.0, angle=0.0, sleep=0):
     """Traffic Play function."""
     env = TorcsEnv(vision=False, throttle=True, gear_change=False)
     ob = None
@@ -50,7 +50,8 @@ def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
             try:
                 ob, r_t, done, info = env.step(step, client, a_t, early_stop)
                 if done:
-                    break
+                    # break
+                    pass
             except Exception as e:
                 print("Exception caught at port " + str(i) + str(e))
                 ob = None

--- a/MADRaS/traffic/lane_switch.py
+++ b/MADRaS/traffic/lane_switch.py
@@ -16,7 +16,7 @@ with open("./MADRaS/MADRaS/traffic/configurations.yml", "r") as ymlfile:
 random.seed(time.time())
 
 
-def playTraffic(port=3101, target_vel=80.0, angle=0.0, sleep=0):
+def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
     """Traffic Play function."""
     env = TorcsEnv(vision=False, throttle=True, gear_change=False)
     ob = None

--- a/MADRaS/traffic/lane_switch.py
+++ b/MADRaS/traffic/lane_switch.py
@@ -4,10 +4,10 @@ import time
 import yaml
 import random
 import numpy as np
-from controllers.pid import PID
-from utils.gym_torcs import TorcsEnv
-import utils.snakeoil3_gym as snakeoil3
-from utils.madras_datatypes import Madras
+from MADRaS.controllers.pid import PID
+from MADRaS.utils.gym_torcs import TorcsEnv
+import MADRaS.utils.snakeoil3_gym as snakeoil3
+from MADRaS.utils.madras_datatypes import Madras
 
 madras = Madras()
 with open("./traffic/configurations.yml", "r") as ymlfile:
@@ -38,7 +38,7 @@ def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
     steer = 0.0
     accel = 0.0
     brake = 0
-    print(velocity)
+    # print(velocity)
     for i in range(episode_count):
         info = {'termination_cause': 0}
         steer = 0.0

--- a/MADRaS/traffic/rand_stop.py
+++ b/MADRaS/traffic/rand_stop.py
@@ -11,7 +11,7 @@ from MADRaS.utils.madras_datatypes import Madras
 
 random.seed(time.time())
 madras = Madras()
-with open("./traffic/configurations.yml", "r") as ymlfile:
+with open("./MADRaS/MADRaS/traffic/configurations.yml", "r") as ymlfile:
     cfg = yaml.load(ymlfile)
 
 

--- a/MADRaS/traffic/rand_stop.py
+++ b/MADRaS/traffic/rand_stop.py
@@ -4,10 +4,10 @@ import time
 import yaml
 import random
 import numpy as np
-from controllers.pid import PID
-from utils.gym_torcs import TorcsEnv
-import utils.snakeoil3_gym as snakeoil3
-from utils.madras_datatypes import Madras
+from MADRaS.controllers.pid import PID
+from MADRaS.utils.gym_torcs import TorcsEnv
+import MADRaS.utils.snakeoil3_gym as snakeoil3
+from MADRaS.utils.madras_datatypes import Madras
 
 random.seed(time.time())
 madras = Madras()

--- a/MADRaS/traffic/rand_stop.py
+++ b/MADRaS/traffic/rand_stop.py
@@ -52,7 +52,7 @@ def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
             try:
                 ob, r_t, done, info = env.step(step, client, a_t, early_stop)
                 if done:
-                    break
+                    pass
             except Exception as e:
                 print("Exception caught at port " + str(i) + str(e))
                 ob = None

--- a/MADRaS/traffic/vel_change.py
+++ b/MADRaS/traffic/vel_change.py
@@ -49,7 +49,7 @@ def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
             try:
                 ob, r_t, done, info = env.step(step, client, a_t, early_stop)
                 if done:
-                    break
+                    pass
             except Exception as e:
                 print("Exception caught at point A at port " + str(i) + str(e))
                 ob = None

--- a/MADRaS/traffic/vel_change.py
+++ b/MADRaS/traffic/vel_change.py
@@ -37,7 +37,7 @@ def playTraffic(port=3101, target_vel=50.0, angle=0.0, sleep=0):
     brake = 0
     A = cfg['traffic']['amplitude'] / 300.0
     T = cfg['traffic']['time_period']
-    print(velocity_i)
+    # print(velocity_i)
     for i in range(episode_count):
         info = {'termination_cause': 0}
         steer = 0.0

--- a/MADRaS/traffic/vel_change.py
+++ b/MADRaS/traffic/vel_change.py
@@ -3,13 +3,13 @@ import sys
 import math
 import yaml
 import numpy as np
-from controllers.pid import PID
-from utils.gym_torcs import TorcsEnv
-import utils.snakeoil3_gym as snakeoil3
-from utils.madras_datatypes import Madras
+from MADRaS.controllers.pid import PID
+from MADRaS.utils.gym_torcs import TorcsEnv
+import MADRaS.utils.snakeoil3_gym as snakeoil3
+from MADRaS.utils.madras_datatypes import Madras
 
 madras = Madras()
-with open("./traffic/configurations.yml", "r") as ymlfile:
+with open("./MADRaS/MADRaS/traffic/configurations.yml", "r") as ymlfile:
     cfg = yaml.load(ymlfile)
 
 

--- a/MADRaS/utils/gym_torcs.py
+++ b/MADRaS/utils/gym_torcs.py
@@ -138,7 +138,7 @@ class TorcsEnv:
         damage = np.array(obs['damage'])
         rpm = np.array(obs['rpm'])
 
-        # progress = sp * np.cos(obs['angle']) - np.abs(sp * np.sin(obs['angle'])) - sp * np.abs(obs['trackPos'])
+        progress = sp * np.cos(obs['angle']) - np.abs(sp * np.sin(obs['angle'])) - sp * np.abs(obs['trackPos'])
         # progress = sp * np.cos(obs['angle']) - np.abs(sp * np.sin(obs['angle'])) 
         progress = 0
         reward = progress

--- a/MADRaS/utils/gym_torcs.py
+++ b/MADRaS/utils/gym_torcs.py
@@ -34,7 +34,7 @@ class TorcsEnv:
         self.visualise = visualise
         self.initial_run = True
         self.time_step = 0
-        self.currState = None 
+        self.currState = None      
         self.no_of_visualisations = no_of_visualisations
         if throttle is False:                           # Throttle is generally True
             self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(1,))
@@ -138,17 +138,22 @@ class TorcsEnv:
         damage = np.array(obs['damage'])
         rpm = np.array(obs['rpm'])
 
-        progress = sp * np.cos(obs['angle']) - np.abs(sp * np.sin(obs['angle'])) - sp * np.abs(obs['trackPos'])
+        # progress = sp * np.cos(obs['angle']) - np.abs(sp * np.sin(obs['angle'])) - sp * np.abs(obs['trackPos'])
+        # progress = sp * np.cos(obs['angle']) - np.abs(sp * np.sin(obs['angle'])) 
+        progress = 0
         reward = progress
 
         # collision detection
         if obs['damage'] - obs_pre['damage'] > 0:
             reward = -1000
+            client.R.d['meta'] = True
+            print('Terminating because crashed')
+
 
         # Termination judgement #########################
         episode_terminate = False
         if ((abs(track.any()) > 1 or abs(trackPos) > 1) and early_stop):  # Episode is terminated if the car is out of track
-            reward = -200
+            reward = -1000
             episode_terminate = True
             client.R.d['meta'] = True
             print('Terminating because Out of Track')
@@ -169,20 +174,19 @@ class TorcsEnv:
         return self.observation, reward, client.R.d['meta'], {}
 
 
-    def reset(self, client, relaunch=True):        
+    def reset(self, client, serverport, agentport, relaunch=True):        
         self.time_step = 0
-        self.port = client.port
         if self.initial_reset is not True:
             # client.R.d['meta'] = True
             # client.respond_to_server()
 
             ## TENTATIVE. Restarting TORCS every episode suffers the memory leak bug!
             if relaunch is True:
-                self.reset_torcs(client)
+                self.reset_torcs(client,serverport)
                 print("### TORCS is RELAUNCHED ###")
 
         # Modify here if you use multiple tracks in the environment
-        client = snakeoil3.Client(p=self.port, vision=self.vision,visualise=self.visualise,no_of_visualisations=self.no_of_visualisations)  # Open new UDP in vtorcs
+        client = snakeoil3.Client(p=agentport, vision=self.vision,visualise=self.visualise,no_of_visualisations=self.no_of_visualisations)  # Open new UDP in vtorcs
         client.MAX_STEPS = np.inf
 
         # client = self.client
@@ -207,8 +211,8 @@ class TorcsEnv:
     def get_obs(self):
         return self.observation
 
-    def reset_torcs(self,client):
-        print("relaunch torcs in gym_torcs on port{}".format(client.port))
+    def reset_torcs(self,client,port):
+        print("relaunch torcs in gym_torcs on port{}".format(port))
         
         command = 'kill {}'.format(client.serverPID)
         os.system(command)
@@ -218,9 +222,9 @@ class TorcsEnv:
         command = None
         rank = MPI.COMM_WORLD.Get_rank()        
         if rank < self.no_of_visualisations and self.visualise:
-            command = 'export TORCS_PORT={} && vglrun torcs -t 10000000 -nolaptime'.format(client.port)
+            command = 'export TORCS_PORT={} && vglrun torcs -t 10000000 -nolaptime'.format(port)
         else:
-            command = 'export TORCS_PORT={} && torcs -t 10000000 -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(client.port)
+            command = 'export TORCS_PORT={} && torcs -t 10000000 -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(port)
         if self.vision is True:
             command += ' -vision'
 

--- a/MADRaS/utils/snakeoil3_gym.py
+++ b/MADRaS/utils/snakeoil3_gym.py
@@ -152,7 +152,7 @@ class Client(object):
         self.trackname = 'unknown'
         self.stage = 3  # 0=Warm-up, 1=Qualifying 2=Race, 3=unknown <Default=3>
         self.debug = False
-        self.maxSteps = 100000  # 50steps/second
+        self.maxSteps = 10000000  # 50steps/second
         # self.parse_the_command_line()
         if H:
             self.host = H
@@ -227,9 +227,9 @@ class Client(object):
                     rank = MPI.COMM_WORLD.Get_rank()
 
                     if rank < self.no_of_visualisations and self.visualise:
-                        command = 'export TORCS_PORT={} && vglrun torcs -nolaptime'.format(self.port)
+                        command = 'export TORCS_PORT={} && vglrun torcs -t 10000000 -nolaptime'.format(self.port)
                     else:
-                        command = 'export TORCS_PORT={} && vglrun torcs -t 10000000  -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
+                        command = 'export TORCS_PORT={} && torcs -t 10000000  -r ~/.torcs/config/raceman/quickrace.xml -nolaptime'.format(self.port)
                     if self.vision is True:
                         command += ' -vision'
                     self.torcs_proc = subprocess.Popen([command], shell=True, preexec_fn=os.setsid)


### PR DESCRIPTION
A flag is used to identify to the mode of training (single or multi agent). This is necessary as in single agent training every instance of the Environment creates a new simulator instance which is not desired in multi agent. When the flag `multi_agent_mode` is set to True simulator instance is not created.

For custom traffic a list of agent numbers is passed to Env. This list determines the traffic agent type. Custom traffic is needed for training agent 

Testing:
For multi agent:
Ran torcs with 4 scr_server players in quick race and connected 4 agents by creating 4 environment instance and each calling reset().

For traffic:
Just run a single agent and set the traffic list to [1,1,1]. Make sure to set enough scr_server agents in torcs simulator.
