### PR TITLE
PID memory bug

### DIFF
--- a/MADRaS/controllers/pid.py
+++ b/MADRaS/controllers/pid.py
@@ -25,6 +25,9 @@ class PID(object):
         return "<PID_onject P: %s I: %s D: %s>"\
             % (self.K[0], self.K[1], self.K[2])
 
+    def reset_pid(self):
+        self.error = np.array([0.0, 0.0, 0.0])
+
     def update_error(self, e):
         """Update Step."""
         self.error[2] = e - self.error[0]

--- a/MADRaS/envs/gym_madras.py
+++ b/MADRaS/envs/gym_madras.py
@@ -147,6 +147,11 @@ class MadrasEnv(TorcsEnv,gym.Env):
                         self.ob.speedX, self.ob.speedY, self.ob.speedZ,
                         self.ob.wheelSpinVel / 100.0, self.ob.rpm))
 
+        self.prev_angle = 0.0
+        self.prev_dist = 0.0
+        self.prev_lane = 0.0
+        self.accel_PID.reset_pid()
+        self.steer_PID.reset_pid()
         return s_t
 
     def step(self, desire):

--- a/MADRaS/utils/gym_torcs.py
+++ b/MADRaS/utils/gym_torcs.py
@@ -60,6 +60,7 @@ class TorcsEnv:
 
 
     def step(self, step, client, u, early_stop=1):
+        reward = 0
         this_action = self.agent_to_torcs(u)
 
         # Apply Action


### PR DESCRIPTION
Why?
Previously it so happened that the error cache of the PID controller was not cleared after each episode, this created a serious unwanted correlation between two episodes.

What?
Created a `pid_reset` function which is called at the end of each episode.

Testing:
```python
import MADRaS
import gym

env = gym.make("Madras-v0")
ob = env.reset()
for i in range(100):
    ob, r, done, _ = env.step([0,0.1])
    print("STEP={},REW={}".format(i,r))


ob = env.reset()

for i in range(100):
    ob, r, done, _ = env.step([0,0.2])
    print("STEP={},REW={}".format(i,r))
```