### PR TITLE
Traffic cars look different from learning car

### DIFF
--- a/MADRaS/envs/data/sim_options.yml
+++ b/MADRaS/envs/data/sim_options.yml
@@ -10,7 +10,9 @@ server_config:
   torcs_server_config_dir: /home/<username>/.torcs/config/raceman/  # This must be the value for TORCS with rendering on
   scr_server_config_dir: /home/<username>/usr/local/share/games/torcs/drivers/scr_server/
   traffic_car: p406           # get full list of cars here: /home/anirban/usr/local/share/games/torcs/cars/
-  learning_car: car1-stock1   # get full list of cars here: /home/anirban/usr/local/share/games/torcs/cars/
+  learning_car:               # get full list of cars here: /home/anirban/usr/local/share/games/torcs/cars/
+    - car1-stock1
+    - car1-stock2
 
 randomize_env: True
 vision: False  # whether to use vision input

--- a/MADRaS/envs/data/sim_options.yml
+++ b/MADRaS/envs/data/sim_options.yml
@@ -7,7 +7,10 @@ server_config:
     - alpine-1
     - alpine-2
   distance_to_start: 25
-  torcs_server_config_path: /home/<username>/.torcs/config/raceman/  # This must be the value for TORCS with rendering on
+  torcs_server_config_dir: /home/<username>/.torcs/config/raceman/  # This must be the value for TORCS with rendering on
+  scr_server_config_dir: /home/<username>/usr/local/share/games/torcs/drivers/scr_server/
+  traffic_car: p406           # get full list of cars here: /home/anirban/usr/local/share/games/torcs/cars/
+  learning_car: car1-stock1   # get full list of cars here: /home/anirban/usr/local/share/games/torcs/cars/
 
 randomize_env: True
 vision: False  # whether to use vision input

--- a/MADRaS/utils/data/car_config.template
+++ b/MADRaS/utils/data/car_config.template
@@ -1,0 +1,4 @@
+        <section name="{section_no}">
+            <attnum name="idx" val="{car_no}"/>
+            <attstr name="module" val="scr_server"/>
+        </section>

--- a/MADRaS/utils/data/quickrace.template
+++ b/MADRaS/utils/data/quickrace.template
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE params SYSTEM "params.dtd">
+
+
+<params name="Quick Race">
+  <section name="Header">
+    <attstr name="name" val="Quick Race"/>
+    <attstr name="description" val="Quick Race"/>
+    <attnum name="priority" val="10"/>
+    <attstr name="menu image" val="data/img/splash-qr.png"/>
+  </section>
+
+  <section name="Tracks">
+    <attnum name="maximum number" val="1"/>
+    <section name="1">
+      <attstr name="name" val="{track_name}"/>
+      <attstr name="category" val="{track_category}"/>
+    </section>
+
+  </section>
+
+  <section name="Races">
+    <section name="1">
+      <attstr name="name" val="Quick Race"/>
+    </section>
+
+  </section>
+
+  <section name="Quick Race">
+    <attnum name="distance" unit="km" val="0"/>
+    <attstr name="type" val="race"/>
+    <attstr name="starting order" val="drivers list"/>
+    <attstr name="restart" val="yes"/>
+    <attnum name="laps" val="1"/>
+    <section name="Starting Grid">
+      <attnum name="rows" val="2"/>
+      <attnum name="distance to start" val="{distance_to_start}"/>
+      <attnum name="distance between columns" val="20"/>
+      <attnum name="offset within a column" val="10"/>
+      <attnum name="initial speed" val="0"/>
+      <attnum name="initial height" val="0.2"/>
+    </section>
+
+  </section>
+
+  <section name="Drivers">
+    <attnum name="maximum number" val="40"/>
+    <attnum name="focused idx" val="0"/>
+    <attstr name="focused module" val="scr_server"/>
+    {car_config}
+
+  </section>
+
+  <section name="Configuration">
+    <attnum name="current configuration" val="4"/>
+    <section name="1">
+      <attstr name="type" val="track select"/>
+    </section>
+
+    <section name="2">
+      <attstr name="type" val="drivers select"/>
+    </section>
+
+    <section name="3">
+      <attstr name="type" val="race config"/>
+      <attstr name="race" val="Quick Race"/>
+      <section name="Options">
+        <section name="1">
+          <attstr name="type" val="race length"/>
+        </section>
+
+      </section>
+
+    </section>
+
+  </section>
+
+</params>

--- a/MADRaS/utils/data/scr_server_config.template
+++ b/MADRaS/utils/data/scr_server_config.template
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    file                 : scr_server.xml
+    created              : Tue Dec 18 23:40:54 CET 2007
+    copyright            : (C) 2002 Daniele Loiacono
+-->
+
+<!--    This program is free software; you can redistribute it and/or modify  -->
+<!--    it under the terms of the GNU General Public License as published by  -->
+<!--    the Free Software Foundation; either version 2 of the License, or     -->
+<!--    (at your option) any later version.                                   -->
+
+<!DOCTYPE params SYSTEM "../../libs/tgf/params.dtd">
+<params name="scr_server" type="robotdef">
+  <section name="Robots">
+    <section name="index">
+      <section name="0">
+	<attstr name="name" val="scr_server 1"></attstr>
+	<attstr name="desc" val=""></attstr>
+	<attstr name="team" val=""></attstr>
+	<attstr name="author" val="Daniele Loiacono"></attstr>
+	<attstr name="car name" val="{}"></attstr>
+	<attnum name="race number" val="1"></attnum>
+	<attnum name="red" val="1.0"></attnum>
+	<attnum name="green" val="1.0"></attnum>
+	<attnum name="blue" val="1.0"></attnum>
+      </section>
+      <section name="1">
+	<attstr name="name" val="scr_server 2"></attstr>
+	<attstr name="desc" val=""></attstr>
+	<attstr name="team" val=""></attstr>
+	<attstr name="author" val="Daniele Loiacono"></attstr>
+	<attstr name="car name" val="{}"></attstr>
+	<attnum name="race number" val="2"></attnum>
+	<attnum name="red" val="1.0"></attnum>
+	<attnum name="green" val="1.0"></attnum>
+	<attnum name="blue" val="1.0"></attnum>
+      </section>
+      <section name="2">
+	<attstr name="name" val="scr_server 3"></attstr>
+	<attstr name="desc" val=""></attstr>
+	<attstr name="team" val=""></attstr>
+	<attstr name="author" val="Daniele Loiacono"></attstr>
+	<attstr name="car name" val="{}"></attstr>
+	<attnum name="race number" val="3"></attnum>
+	<attnum name="red" val="1.0"></attnum>
+	<attnum name="green" val="1.0"></attnum>
+	<attnum name="blue" val="1.0"></attnum>
+      </section>
+      <section name="3">
+	<attstr name="name" val="scr_server 4"></attstr>
+	<attstr name="desc" val=""></attstr>
+	<attstr name="team" val=""></attstr>
+	<attstr name="author" val="Daniele Loiacono"></attstr>
+	<attstr name="car name" val="{}"></attstr>
+	<attnum name="race number" val="4"></attnum>
+	<attnum name="red" val="1.0"></attnum>
+	<attnum name="green" val="1.0"></attnum>
+	<attnum name="blue" val="1.0"></attnum>
+      </section>
+      <section name="4">
+	<attstr name="name" val="scr_server 5"></attstr>
+	<attstr name="desc" val=""></attstr>
+	<attstr name="team" val=""></attstr>
+	<attstr name="author" val="Daniele Loiacono"></attstr>
+	<attstr name="car name" val="{}"></attstr>
+	<attnum name="race number" val="5"></attnum>
+	<attnum name="red" val="1.0"></attnum>
+	<attnum name="green" val="1.0"></attnum>
+	<attnum name="blue" val="1.0"></attnum>
+      </section>
+      <section name="5">
+	<attstr name="name" val="scr_server 6"></attstr>
+	<attstr name="desc" val=""></attstr>
+	<attstr name="team" val=""></attstr>
+	<attstr name="author" val="Daniele Loiacono"></attstr>
+	<attstr name="car name" val="{}"></attstr>
+	<attnum name="race number" val="6"></attnum>
+	<attnum name="red" val="1.0"></attnum>
+	<attnum name="green" val="1.0"></attnum>
+	<attnum name="blue" val="1.0"></attnum>
+      </section>
+      <section name="6">
+	<attstr name="name" val="scr_server 7"></attstr>
+	<attstr name="desc" val=""></attstr>
+	<attstr name="team" val=""></attstr>
+	<attstr name="author" val="Daniele Loiacono"></attstr>
+	<attstr name="car name" val="{}"></attstr>
+	<attnum name="race number" val="7"></attnum>
+	<attnum name="red" val="1.0"></attnum>
+	<attnum name="green" val="1.0"></attnum>
+	<attnum name="blue" val="1.0"></attnum>
+      </section>
+      <section name="7">
+	<attstr name="name" val="scr_server 8"></attstr>
+	<attstr name="desc" val=""></attstr>
+	<attstr name="team" val=""></attstr>
+	<attstr name="author" val="Daniele Loiacono"></attstr>
+	<attstr name="car name" val="{}"></attstr>
+	<attnum name="race number" val="8"></attnum>
+	<attnum name="red" val="1.0"></attnum>
+	<attnum name="green" val="1.0"></attnum>
+	<attnum name="blue" val="1.0"></attnum>
+      </section>
+      <section name="8">
+	<attstr name="name" val="scr_server 9"></attstr>
+	<attstr name="desc" val=""></attstr>
+	<attstr name="team" val=""></attstr>
+	<attstr name="author" val="Daniele Loiacono"></attstr>
+	<attstr name="car name" val="{}"></attstr>
+	<attnum name="race number" val="9"></attnum>
+	<attnum name="red" val="1.0"></attnum>
+	<attnum name="green" val="1.0"></attnum>
+	<attnum name="blue" val="1.0"></attnum>
+      </section>
+      <section name="9">
+	<attstr name="name" val="scr_server 10"></attstr>
+	<attstr name="desc" val=""></attstr>
+	<attstr name="team" val=""></attstr>
+	<attstr name="author" val="Daniele Loiacono"></attstr>
+	<attstr name="car name" val="{}"></attstr>
+	<attnum name="race number" val="10"></attnum>
+	<attnum name="red" val="1.0"></attnum>
+	<attnum name="green" val="1.0"></attnum>
+	<attnum name="blue" val="1.0"></attnum>
+      </section>
+</section>
+  </section>
+</params>

--- a/MADRaS/utils/torcs_server_config.py
+++ b/MADRaS/utils/torcs_server_config.py
@@ -4,6 +4,13 @@ import os
 import logging
 logger = logging.getLogger(__name__)
 
+path_and_file = os.path.realpath(__file__)
+path, _ = os.path.split(path_and_file)
+
+QUICKRACE_TEMPLATE_PATH = os.path.join(path, "data", "quickrace.template")
+CAR_CONFIG_TEMPATE_PATH = os.path.join(path, "data", "car_config.template")
+SCR_SERVER_CONFIG_TEMPLATE_PATH = os.path.join(path, "data", "scr_server_config.template")
+
 MAX_NUM_CARS = 10  # There are 10 scr-servers in the TORCS GUI
 TRACK_NAMES = [
     "aalborg",
@@ -29,91 +36,6 @@ TRACK_NAMES = [
     "wheel-2"
 ]
 
-QUICKRACE_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE params SYSTEM "params.dtd">
-
-
-<params name="Quick Race">
-  <section name="Header">
-    <attstr name="name" val="Quick Race"/>
-    <attstr name="description" val="Quick Race"/>
-    <attnum name="priority" val="10"/>
-    <attstr name="menu image" val="data/img/splash-qr.png"/>
-  </section>
-
-  <section name="Tracks">
-    <attnum name="maximum number" val="1"/>
-    <section name="1">
-      <attstr name="name" val="{track_name}"/>
-      <attstr name="category" val="{track_category}"/>
-    </section>
-
-  </section>
-
-  <section name="Races">
-    <section name="1">
-      <attstr name="name" val="Quick Race"/>
-    </section>
-
-  </section>
-
-  <section name="Quick Race">
-    <attnum name="distance" unit="km" val="0"/>
-    <attstr name="type" val="race"/>
-    <attstr name="starting order" val="drivers list"/>
-    <attstr name="restart" val="yes"/>
-    <attnum name="laps" val="1"/>
-    <section name="Starting Grid">
-      <attnum name="rows" val="2"/>
-      <attnum name="distance to start" val="{distance_to_start}"/>
-      <attnum name="distance between columns" val="20"/>
-      <attnum name="offset within a column" val="10"/>
-      <attnum name="initial speed" val="0"/>
-      <attnum name="initial height" val="0.2"/>
-    </section>
-
-  </section>
-
-  <section name="Drivers">
-    <attnum name="maximum number" val="40"/>
-    <attnum name="focused idx" val="0"/>
-    <attstr name="focused module" val="scr_server"/>
-    {car_config}
-
-  </section>
-
-  <section name="Configuration">
-    <attnum name="current configuration" val="4"/>
-    <section name="1">
-      <attstr name="type" val="track select"/>
-    </section>
-
-    <section name="2">
-      <attstr name="type" val="drivers select"/>
-    </section>
-
-    <section name="3">
-      <attstr name="type" val="race config"/>
-      <attstr name="race" val="Quick Race"/>
-      <section name="Options">
-        <section name="1">
-          <attstr name="type" val="race length"/>
-        </section>
-
-      </section>
-
-    </section>
-
-  </section>
-
-</params>
-"""
-
-CAR_CONFIG_TEMPATE = """<section name="{section_no}">
-      <attnum name="idx" val="{car_no}"/>
-      <attstr name="module" val="scr_server"/>
-    </section>
-"""
 
 class TorcsConfig(object):
     def __init__(self, cfg, randomize=False):
@@ -121,12 +43,21 @@ class TorcsConfig(object):
         self.track_category = "road"  # for test purposes - will add "dirt" later
         self.track_names = cfg["track_names"] if  "track_names" in cfg else TRACK_NAMES
         self.distance_to_start = cfg["distance_to_start"] if "distance_to_start" in cfg else 0
-        self.torcs_server_config_path = cfg["torcs_server_config_path"] if "torcs_server_config_path" in cfg else "/tmp"
-        self.template = QUICKRACE_TEMPLATE
-        self.car_config_template = CAR_CONFIG_TEMPATE
-        self.randomize = randomize
-        os.system("mkdir -p {}".format(self.torcs_server_config_path))
-        self.quickrace_path = os.path.join(self.torcs_server_config_path, "quickrace.xml")
+        self.torcs_server_config_dir = (cfg["torcs_server_config_dir"] if "torcs_server_config_dir" in cfg
+                                        else "/home/anirban/.torcs/config/raceman/")
+        self.scr_server_config_dir = (cfg["scr_server_config_dir"] if "scr_server_config_dir" in cfg
+                                          else "/home/anirban/usr/local/share/games/torcs/drivers/scr_server/")
+        with open(QUICKRACE_TEMPLATE_PATH, 'r') as f:
+            self.quickrace_template = f.read()
+        with open(CAR_CONFIG_TEMPATE_PATH, 'r') as f:
+            self.car_config_template = f.read()
+        with open(SCR_SERVER_CONFIG_TEMPLATE_PATH, 'r') as f:
+            self.scr_server_config_template = f.read()
+        self.randomize = randomize)
+        self.quickrace_xml_path = os.path.join(self.torcs_server_config_dir, "quickrace.xml")
+        self.scr_server_xml_path = os.path.join(self.scr_server_config_dir, "scr_server.xml")
+        self.traffic_car_type = cfg['traffic_car']
+        self.learning_car_type = cfg['learning_car']
 
     def get_num_traffic_cars(self):
         if not self.randomize:
@@ -147,15 +78,21 @@ class TorcsConfig(object):
         self.num_traffic_cars = self.get_num_traffic_cars()
         self.num_learning_cars = 1
 
-        car_config = "\n    ".join(self.car_config_template.format(
-                               **{"section_no": i+1, "car_no": i}) for i in range(
-                                  self.num_traffic_cars + self.num_learning_cars))
+        car_config = "\n".join(self.car_config_template.format(
+                      **{"section_no": i+1, "car_no": i}) for i in range(
+                        self.num_traffic_cars + self.num_learning_cars))
         context = {
             "track_name": self.get_track_name(),
             "track_category": self.track_category,
             "distance_to_start": self.distance_to_start,
             "car_config": car_config
         }
-        torcs_server_config = self.template.format(**context)
-        with open(self.quickrace_path, "w") as f:
+        torcs_server_config = self.quickrace_template.format(**context)
+        with open(self.quickrace_xml_path, "w") as f:
             f.write(torcs_server_config)
+
+        car_name_list = ([self.traffic_car_type]*self.num_traffic_cars + [self.learning_car_type] +
+                         [self.traffic_car_type]*(MAX_NUM_CARS-self.num_traffic_cars-1))
+        scr_server_config = self.scr_server_config_template.format(*car_name_list)
+        with open(self.scr_server_xml_path, "w") as f:
+            f.write(scr_server_config)

--- a/MADRaS/utils/torcs_server_config.py
+++ b/MADRaS/utils/torcs_server_config.py
@@ -53,11 +53,11 @@ class TorcsConfig(object):
             self.car_config_template = f.read()
         with open(SCR_SERVER_CONFIG_TEMPLATE_PATH, 'r') as f:
             self.scr_server_config_template = f.read()
-        self.randomize = randomize)
+        self.randomize = randomize
         self.quickrace_xml_path = os.path.join(self.torcs_server_config_dir, "quickrace.xml")
         self.scr_server_xml_path = os.path.join(self.scr_server_config_dir, "scr_server.xml")
         self.traffic_car_type = cfg['traffic_car']
-        self.learning_car_type = cfg['learning_car']
+        self.learning_car_types = cfg['learning_car']
 
     def get_num_traffic_cars(self):
         if not self.randomize:
@@ -74,6 +74,13 @@ class TorcsConfig(object):
         logging.info("-------------------------CURRENT TRACK:{}------------------------".format(track_name))
         return track_name
 
+    def get_learning_car_type(self):
+        if not self.randomize:
+            learning_car_type = self.learning_car_types[0]
+        else:
+            learning_car_type = random.sample(self.learning_car_types, 1)[0]
+        return learning_car_type
+  
     def generate_torcs_server_config(self):
         self.num_traffic_cars = self.get_num_traffic_cars()
         self.num_learning_cars = 1
@@ -90,7 +97,7 @@ class TorcsConfig(object):
         torcs_server_config = self.quickrace_template.format(**context)
         with open(self.quickrace_xml_path, "w") as f:
             f.write(torcs_server_config)
-
+        self.learning_car_type = self.get_learning_car_type()
         car_name_list = ([self.traffic_car_type]*self.num_traffic_cars + [self.learning_car_type] +
                          [self.traffic_car_type]*(MAX_NUM_CARS-self.num_traffic_cars-1))
         scr_server_config = self.scr_server_config_template.format(*car_name_list)


### PR DESCRIPTION
### Issue:
- All traffic agents and learning agents looked the same creating confusion during visualization.
- MADRaS was not able to vary the model of the car during training. As a result it was not capable of training the driving agent to be resilient to the engine dynamics of the vehicle.

### Contribution:
- Traffic agents and learning agents look different. The make of cars for traffic and learning agents can be specified in the `sim_options.yml` file.
- The model of the car presented to the learning agent is randomly changed at the beginning of each episode. This adds a third axis of variability to `MadrasEnv` after track and traffic.

### Smoke tests:
- Insert `username` in `sim_options.yml` and turn `visualization` on.
- Run `python MADRaS/agents/generic/test_environment.py`. Watch out for car colors.
- Turn `visualization` off in `sim_options.yml`.
- Run `python MADRaS/agents/rllib/train_rllib_agent.py`.